### PR TITLE
pep8 compliance, implementing raw_query

### DIFF
--- a/test_api.py
+++ b/test_api.py
@@ -12,7 +12,7 @@ class TestAPI(object):
         api = overpass.API()
         #osm_elements = api.Get(overpass.MapQuery(37.86517,-122.31851,37.86687,-122.31635))
         #print 'DEB osm_elements:', geojson.dumps(osm_elements,sort_keys=True,indent=2)
-        osm_geo = api.Get(overpass.MapQuery(37.86517, -122.31851, 37.86687, -122.31635), asGeoJSON=True)
+        osm_geo = api.get(overpass.MapQuery(37.86517, -122.31851, 37.86687, -122.31635), asGeoJSON=True)
         #with open('test.geojson','w') as f:
         #    geojson.dump(osm_geo,f,indent=2,sort_keys=True)
         assert len(osm_geo['features']) > 1


### PR DESCRIPTION
This PR:
- changes public function names to lowercase
- adds a `raw_query()` public function for complete QL queries.
- removes the stub of a `search()` function (better implemented in the costom queries.)
- raises the `OverpassException` rather than exiting with a print statement.
- adds some docstrings.
