### PR TITLE
Substitute post for get.  Received 414 error when requesting large poly

### DIFF
--- a/overpass/api.py
+++ b/overpass/api.py
@@ -83,11 +83,12 @@ class API(object):
         payload = {"data": query}
 
         try:
-            r = requests.get(
+            r = requests.post(
                 self.endpoint,
-                params=payload,
+                data=payload,
                 timeout=self.timeout
             )
+            
         except requests.exceptions.Timeout:
             raise TimeoutError(self._timeout)
 


### PR DESCRIPTION
query.

http://www.overpass-api.de/command_line.html

http://en.wikipedia.org/wiki/POST_(HTTP)