### PR TITLE
Handle server runtime error from overpass API

### DIFF
--- a/overpass/api.py
+++ b/overpass/api.py
@@ -2,7 +2,8 @@ import requests
 import json
 import geojson
 
-from .errors import OverpassSyntaxError, TimeoutError, MultipleRequestsError, ServerLoadError, UnknownOverpassError
+from .errors import (OverpassSyntaxError, TimeoutError, MultipleRequestsError,
+                     ServerLoadError, UnknownOverpassError, ServerRuntimeError)
 
 
 class API(object):
@@ -47,6 +48,10 @@ class API(object):
 
         if "elements" not in response:
             raise UnknownOverpassError("Received an invalid answer from Overpass.")
+
+        remark = response.get('remark', None)
+        if remark is not None and remark.startswith('runtime error'):
+            raise ServerRuntimeError(remark)
 
         if not asGeoJSON:
             return response

--- a/overpass/errors.py
+++ b/overpass/errors.py
@@ -35,3 +35,10 @@ class UnknownOverpassError(OverpassError):
 
     def __init__(self, message):
         self.message = message
+
+
+class ServerRuntimeError(OverpassError):
+    """The Overpass server returned a runtime error"""
+
+    def __init__(self, message):
+        self.message = message


### PR DESCRIPTION
I used this project to send the following query:

    area["ISO3166-1"="US"]->.search;
    (
      node[industrial=brewery](area.search);
      node[microbrewery=yes](area.search);
      node[craft=brewery](area.search);
      way[industrial=brewery](area.search);
      way[microbrewery=yes](area.search);
      way[craft=brewery](area.search);
      relation[industrial=brewery](area.search);
      relation[microbrewery=yes](area.search);
      relation[craft=brewery](area.search);
    );
    out geom;

But after a while I got an empty response. After digging a bit more I found that the overpass API returned a response akin to the one described here: https://github.com/drolbr/Overpass-API/issues/104

Strangely enough the response had a 200 OK status code, so this lib continued to return the empty elements array, leaving me none the wiser.

This PR tries to remedy this, by raising a ServerRuntimeError exception when this happens.






