### PR TITLE
Fixing obsolete CLI

### DIFF
--- a/overpass/cli.py
+++ b/overpass/cli.py
@@ -7,19 +7,14 @@ import overpass
 
 
 @click.command()
-@click.option('--timeout', default=25, help='Timeout in seconds.')
+@click.option('--timeout', default=25, help='Timeout in seconds (default: 25).')
 @click.option('--endpoint', default='http://overpass-api.de/api/interpreter',
     help='URL of your prefered API.')
-@click.option('--responseformat', default='geojson', help="""Format to save the data.
-    Options are 'geojson' and 'osm'. Default format is geojson.""")
+@click.option('--responseformat', type=click.Choice(overpass.API.SUPPORTED_FORMATS), default='geojson',
+        help="Required output format.")
 @click.argument('query', type=str)
 def cli(timeout, endpoint, responseformat, query):
     """Run query"""
     api = overpass.API(timeout=timeout, endpoint=endpoint)
-    if responseformat not in api.SUPPORTED_FORMATS:
-        print("format {} not supported. Supported formats: {}".format(
-            responseformat,
-            ", ".join(api.SUPPORTED_FORMATS)))
-        sys.exit(1)
     result = api.Get(query, responseformat=responseformat)
     click.echo(result)


### PR DESCRIPTION
The help message is not correct (it includes 'osm' format which is not supported by the API). This PR corrects the issues and simplifies the implementation using click.Choice.