### PR TITLE
enable csv response format

### DIFF
--- a/overpass/api.py
+++ b/overpass/api.py
@@ -44,7 +44,7 @@ class API(object):
         # Get the response from Overpass
         raw_response = self._GetFromOverpass(full_query)
 
-        if responseformat == "xml":
+        if responseformat == "xml" or responseformat.startswith("csv"):
             return raw_response
             
         response = json.loads(raw_response)


### PR DESCRIPTION
Implicitly the CSV response format would already work by specifying e.g. `responseformat='csv("addr:street", "addr:place", "addr:housenumber";true;";")'`. But instead of trying to parse JSON the raw response should be returned.

Failed checks are timeout errors.