### PR TITLE
Added correct import for python 3

### DIFF
--- a/overpass/api.py
+++ b/overpass/api.py
@@ -25,7 +25,12 @@ class API(object):
         self._status = None
 
         if self.debug:
-            import httplib
+            # Python 3 compatibility
+            try:
+                import httplib
+            except ImportError:
+                import http.client as httplib
+                
             import logging
             httplib.HTTPConnection.debuglevel = 1
 


### PR DESCRIPTION
For issue #53, hopefully should import http.client if httplib can't be found (the user is using Python 3)