### PR TITLE
Revert "Change to https as http is no longer supported on overpass-ap…

### DIFF
--- a/overpass/api.py
+++ b/overpass/api.py
@@ -12,7 +12,7 @@ class API(object):
 
     # defaults for the API class
     _timeout = 25  # seconds
-    _endpoint = "https://overpass-api.de/api/interpreter"
+    _endpoint = "http://overpass-api.de/api/interpreter"
     _debug = False
 
     _QUERY_TEMPLATE = "[out:{out}];{query}out {verbosity};"


### PR DESCRIPTION
…i.de"

Turns out this was only a temporary issue with http (later on https was
affected as well). As http is working again the change is reverted.