### PR TITLE
fix bug in complete ways and relations query

### DIFF
--- a/overpass/queries.py
+++ b/overpass/queries.py
@@ -4,7 +4,7 @@
 class MapQuery(object):
     """Query to retrieve complete ways and relations in an area."""
 
-    _QUERY_TEMPLATE = "(node({south},{west},{north},{east});<;);"
+    _QUERY_TEMPLATE = "(node({south},{west},{north},{east});<;>;);"
 
     def __init__(self, south, west, north, east):
         """


### PR DESCRIPTION
based on the Overpass API wiki, the Overpass QL of [completed ways and relations](http://wiki.openstreetmap.org/wiki/Overpass_API/Advanced_examples) should be

> (
  node(50.746,7.154,50.748,7.157);
  <;
  >;
);
out meta;
