### PR TITLE
Fixed api output for build=False #93

### DIFF
--- a/overpass/api.py
+++ b/overpass/api.py
@@ -81,10 +81,13 @@ class API(object):
             for row in reader:
                 result.append(row)
             return result
-        elif content_type == "text/xml" or content_type == "application/xml":
+        elif content_type in ("text/xml", "application/xml", "application/osm3s+xml"):
             return r.text
+        elif content_type == "application/json":
+            response = json.loads(r.text)
 
-        response = json.loads(r.text)
+        if not build:
+            return response
 
         # Check for valid answer from Overpass.
         # A valid answer contains an 'elements' key at the root level.


### PR DESCRIPTION
A small modification was made.

When `build=False` and the content-type of the response is 'json', a dict will be returned. If the it is 'csv' or 'xml', `result` will be returned, thus no change was made.


