### PR TITLE
Add date parameter to query builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ We will construct a valid Overpass QL query from the parameters you set by defau
 #### `date`
 
 You can query the data as it was on a given date. You can give either a standard ISO date alone (YYYY-MM-DD) or a full overpass date and time (YYYY-MM-DDTHH:MM:SSZ, i.e. 2020-04-28T00:00:00Z).
+You can also directly pass a `date` or `datetime` object from the `datetime` library.
 
 ### Pre-cooked Queries: `MapQuery`, `WayQuery`
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ response = api.get('node["name"="Salt Lake City"]')
 
 `response` will be a dictionary representing the
 JSON output you would get [from the Overpass API
-directly](https://overpass-api.de/output_formats.html#json). 
+directly](https://overpass-api.de/output_formats.html#json).
 
 **Note that the Overpass query passed to `get()` should not contain any `out` or other meta statements.** See `verbosity` below for how to control the output.
 
@@ -98,7 +98,11 @@ response = api.get('node["name"="Salt Lake City"]', responseformat="xml")
 
 We will construct a valid Overpass QL query from the parameters you set by default. This means you don't have to include 'meta' statements like `[out:json]`, `[timeout:60]`, `[out body]`, etcetera. You just supply the meat of the query, the part that actually tells Overpass what to query for. If for whatever reason you want to override this and supply a full, valid Overpass QL query, you can set `build` to `False` to make the API not do any pre-processing.
 
-### Pre-cooked Queries: `MapQuery`, `WayQuery` 
+#### `date`
+
+You can query the data as it was on a given date. You can give either a standard ISO date alone (YYYY-MM-DD) or a full overpass date and time (YYYY-MM-DDTHH:MM:SSZ, i.e. 2020-04-28T00:00:00Z).
+
+### Pre-cooked Queries: `MapQuery`, `WayQuery`
 
 In addition to just sending your query and parse the result, `overpass`
 provides shortcuts for often used map queries. To use them, just pass

--- a/overpass/api.py
+++ b/overpass/api.py
@@ -8,6 +8,7 @@ import json
 import csv
 import geojson
 import logging
+from datetime import datetime
 from shapely.geometry import Polygon, Point
 from io import StringIO
 from .errors import (
@@ -42,8 +43,8 @@ class API(object):
     _debug = False
     _proxies = None
 
-    _QUERY_TEMPLATE = "[out:{out}];{query}out {verbosity};"
-    _GEOJSON_QUERY_TEMPLATE = "[out:json];{query}out {verbosity};"
+    _QUERY_TEMPLATE = "[out:{out}]{date};{query}out {verbosity};"
+    _GEOJSON_QUERY_TEMPLATE = "[out:json]{date};{query}out {verbosity};"
 
     def __init__(self, *args, **kwargs):
         self.endpoint = kwargs.get("endpoint", self._endpoint)
@@ -70,7 +71,7 @@ class API(object):
             requests_log.setLevel(logging.DEBUG)
             requests_log.propagate = True
 
-    def get(self, query, responseformat="geojson", verbosity="body", build=True):
+    def get(self, query, responseformat="geojson", verbosity="body", build=True, date=''):
         """Pass in an Overpass query in Overpass QL.
 
         :param query: the Overpass QL query to send to the endpoint
@@ -81,11 +82,17 @@ class API(object):
                           "body geom qt"
         :param build: boolean to indicate whether to build the overpass query from a template (True)
                           or allow the programmer to specify full query manually (False)
+        :param date: a date with an optional time. Example: 2020-04-27 or 2020-04-27T00:00:00Z
         """
+        if date:
+            try:
+                date = datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')
+            except ValueError:
+                date = datetime.strptime(date, '%Y-%m-%d')
         # Construct full Overpass query
         if build:
             full_query = self._construct_ql_query(
-                query, responseformat=responseformat, verbosity=verbosity
+                query, responseformat=responseformat, verbosity=verbosity, date=date
             )
         else:
             full_query = query
@@ -137,18 +144,22 @@ class API(object):
     Get = get
     Search = search
 
-    def _construct_ql_query(self, userquery, responseformat, verbosity):
+    def _construct_ql_query(self, userquery, responseformat, verbosity, date):
         raw_query = str(userquery).rstrip()
         if not raw_query.endswith(";"):
             raw_query += ";"
 
+        if date:
+            date = f'[date:"{date.strftime("%Y-%m-%dT%H:%M:%SZ")}"]'
+
         if responseformat == "geojson":
             template = self._GEOJSON_QUERY_TEMPLATE
-            complete_query = template.format(query=raw_query, verbosity=verbosity)
+            complete_query = template.format(
+                query=raw_query, verbosity=verbosity, date=date)
         else:
             template = self._QUERY_TEMPLATE
             complete_query = template.format(
-                query=raw_query, out=responseformat, verbosity=verbosity
+                query=raw_query, out=responseformat, verbosity=verbosity, date=date
             )
 
         if self.debug:

--- a/overpass/api.py
+++ b/overpass/api.py
@@ -9,6 +9,7 @@ import csv
 import geojson
 import logging
 from datetime import datetime
+
 from shapely.geometry import Polygon, Point
 from io import StringIO
 from .errors import (

--- a/overpass/api.py
+++ b/overpass/api.py
@@ -9,7 +9,6 @@ import csv
 import geojson
 import logging
 from datetime import datetime
-
 from shapely.geometry import Polygon, Point
 from io import StringIO
 from .errors import (

--- a/overpass/api.py
+++ b/overpass/api.py
@@ -84,11 +84,13 @@ class API(object):
                           or allow the programmer to specify full query manually (False)
         :param date: a date with an optional time. Example: 2020-04-27 or 2020-04-27T00:00:00Z
         """
-        if date:
+        if date and not isinstance(date, datetime):
+            # If date is given and is not already a datetime, attempt to parse from string
             try:
-                date = datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')
+                date = datetime.fromisoformat(date)
             except ValueError:
-                date = datetime.strptime(date, '%Y-%m-%d')
+                # The 'Z' in a standard overpass date will through fromisoformat() off
+                date = datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')
         # Construct full Overpass query
         if build:
             full_query = self._construct_ql_query(

--- a/overpass/api.py
+++ b/overpass/api.py
@@ -84,12 +84,12 @@ class API(object):
                           or allow the programmer to specify full query manually (False)
         :param date: a date with an optional time. Example: 2020-04-27 or 2020-04-27T00:00:00Z
         """
-        if date and not isinstance(date, datetime):
+        if date and isinstance(date, str):
             # If date is given and is not already a datetime, attempt to parse from string
             try:
                 date = datetime.fromisoformat(date)
             except ValueError:
-                # The 'Z' in a standard overpass date will through fromisoformat() off
+                # The 'Z' in a standard overpass date will throw fromisoformat() off
                 date = datetime.strptime(date, '%Y-%m-%dT%H:%M:%SZ')
         # Construct full Overpass query
         if build:


### PR DESCRIPTION
Allows building a dated Overpass query. The date parameter can be a string in ISO date format (YYYY-MM-DD) or Overpass's datetime format (YYYY-MM-DDTHH:MM:SSZ), or a `date` or `datetime` object from the `datetime` stdlib.