### PR TITLE
Drop python v2.7 and v3.3 from tests, add v3.7–3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: python
 python:
-  - "2.7"
-  - "3.3"
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
+  - "3.8"
+  - "3.9"
 install:
   - "pip install ."
 # command to run tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
-  - "3.9"
 install:
   - "pip install ."
 # command to run tests


### PR DESCRIPTION
The CI for v2.7 and v3.3 have been failing for some time. Both of these versions are EOL and are probably not worth supporting. This PR removes these versions from the travis config while adding v3.7 and v3.8

v3.4 is also EOL, but it is still passing for now.