### PR TITLE
GeoJson MultiPolygon errors with duplicate IDs

### DIFF
--- a/overpass/api.py
+++ b/overpass/api.py
@@ -187,10 +187,16 @@ class API(object):
             return r
 
     def _as_geojson(self, elements):
-
+        ids_already_seen = set()
         features = []
         geometry = None
         for elem in elements:
+            try:
+                if elem["id"] in ids_already_seen:
+                    continue
+                ids_already_seen.add(elem["id"])
+            except KeyError:
+                raise UnknownOverpassError("Received corrupt data from Overpass (no id).")
             elem_type = elem.get("type")
             elem_tags = elem.get("tags")
             elem_geom = elem.get("geometry", [])


### PR DESCRIPTION
sometimes duplicate IDs are returned from a query. OSM then doesn't return their geometry anymore, but only a reference to the previously transmitted element.
When choosing `responseformat=geojson`, this leads to the following error in line 214 and 234: `UnknownOverpassError("Received corrupt data from Overpass (incomplete polygon).")`

Test query: `api.get('relation (52.5,8.3333333,52.75,8.8333333) [water=lake][name="Dümmer"]; out geom;', responseformat="json")`