### PR TITLE
Replace homegrown converter with osm2geojson

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,10 +4,9 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-geojson = ">=1.3.1"
+osm2geojson = ">=0.1.29"
 requests = ">=2.20.0"
 nose = ">=1.3.7"
-shapely = ">=1.6.4"
 
 [dev-packages]
 

--- a/overpass/api.py
+++ b/overpass/api.py
@@ -10,9 +10,8 @@ import re
 from datetime import datetime
 from io import StringIO
 
-import geojson
 import requests
-from shapely.geometry import Point, Polygon
+from osm2geojson import json2geojson
 
 from .errors import (
     MultipleRequestsError,
@@ -134,7 +133,7 @@ class API(object):
             return response
 
         # construct geojson
-        return self._as_geojson(response["elements"])
+        return json2geojson(response)
 
     @staticmethod
     def _api_status() -> dict:
@@ -260,81 +259,3 @@ class API(object):
         else:
             r.encoding = "utf-8"
             return r
-
-    def _as_geojson(self, elements):
-        ids_already_seen = set()
-        features = []
-        geometry = None
-        for elem in elements:
-            try:
-                if elem["id"] in ids_already_seen:
-                    continue
-                ids_already_seen.add(elem["id"])
-            except KeyError:
-                raise UnknownOverpassError("Received corrupt data from Overpass (no id).")
-            elem_type = elem.get("type")
-            elem_tags = elem.get("tags")
-            elem_nodes = elem.get("nodes", None)
-            elem_timestamp = elem.get("timestamp", None)
-            elem_user = elem.get("user", None)
-            elem_uid = elem.get("uid", None)
-            elem_version = elem.get("version", None)
-            if elem_nodes:
-                elem_tags["nodes"] = elem_nodes
-            if elem_user:
-                elem_tags["user"] = elem_user
-            if elem_uid:
-                elem_tags["uid"] = elem_uid  
-            if elem_version:
-                elem_tags["version"] = elem_version                                                
-            elem_geom = elem.get("geometry", [])
-            if elem_type == "node":
-                # Create Point geometry
-                geometry = geojson.Point((elem.get("lon"), elem.get("lat")))
-            elif elem_type == "way":
-                # Create LineString geometry
-                geometry = geojson.LineString([(coords["lon"], coords["lat"]) for coords in elem_geom])
-            elif elem_type == "relation":
-                # Initialize polygon list
-                polygons = []
-                # First obtain the outer polygons
-                for member in elem.get("members", []):
-                    if member["role"] == "outer":
-                        points = [(coords["lon"], coords["lat"]) for coords in member.get("geometry", [])]
-                        # Check that the outer polygon is complete
-                        if points and points[-1] == points[0]:
-                            polygons.append([points])
-                        else:
-                            raise UnknownOverpassError("Received corrupt data from Overpass (incomplete polygon).")
-                # Then get the inner polygons
-                for member in elem.get("members", []):
-                    if member["role"] == "inner":
-                        points = [(coords["lon"], coords["lat"]) for coords in member.get("geometry", [])]
-                        # Check that the inner polygon is complete
-                        if not points or points[-1] != points[0]:
-                            raise UnknownOverpassError("Received corrupt data from Overpass (incomplete polygon).")
-                        # We need to check to which outer polygon the inner polygon belongs
-                        point = Point(points[0])
-                        for poly in polygons:
-                            polygon = Polygon(poly[0])
-                            if polygon.contains(point):
-                                poly.append(points)
-                                break
-                        else:
-                            raise UnknownOverpassError("Received corrupt data from Overpass (inner polygon cannot "
-                                                       "be matched to outer polygon).")
-                # Finally create MultiPolygon geometry
-                if polygons:
-                    geometry = geojson.MultiPolygon(polygons)
-            else:
-                raise UnknownOverpassError("Received corrupt data from Overpass (invalid element).")
-
-            if geometry:
-                feature = geojson.Feature(
-                    id=elem["id"],
-                    geometry=geometry,
-                    properties=elem_tags
-                )
-                features.append(feature)
-
-        return geojson.FeatureCollection(features)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 geojson>=1.3.1
-requests>=2.8.1
 nose>=1.3.7
-shapely>=1.6.4
+osm2geojson
+requests>=2.8.1

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
         "Topic :: Scientific/Engineering :: GIS",
         "Topic :: Utilities",
     ],
-    install_requires=["requests>=2.3.0", "geojson>=1.0.9", "shapely>=1.6.4"],
-    extras_require={"test": ["pytest"]},
+    install_requires=["requests>=2.3.0", "osm2geojson"],
+    extras_require={"test": ["pytest", "geojson>=1.0.9"]},
 )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -54,6 +54,13 @@ def test_geojson_extended():
     ref_geo = geojson.load(open(os.path.join(os.path.dirname(__file__), "example.json"), "r"))
     assert osm_geo==ref_geo
 
+def test_multipolygon():
+    """
+    Test that multipolygons are processed without error
+    """
+    api = overpass.API()
+    api.get("rel(11038555)", verbosity="body geom")
+
 
 def test_slots_available():
     api = overpass.API(debug=True)


### PR DESCRIPTION
Replaces the built-in method to convert Overpass JSON to geojson with the [osm2geojson](https://pypi.org/project/osm2geojson/) library. The motivation is to reduce the scope of this library and offload some maintenance burden.

Important differences:
* osm2geojson uses 7-digit coordinate precision, same as the Overpass JSON. This lib has been using 6-digit geojson up until now
* osm2geojson nests the `id` attribute under `properties`, this lib has been putting `id` as a top-level attribute

Setting as a draft PR until either it is decided that these differences are acceptable, or either osm2geojson or this PR is modified to produce identical output.

Closes #135 and possibly some others?