### PR TITLE
Handle variable numbers of lines in Overpass status page

### DIFF
--- a/overpass/api.py
+++ b/overpass/api.py
@@ -148,9 +148,13 @@ class API(object):
 
         available_re = re.compile(r'\d(?= slots? available)')
         available_slots = int(
-            available_re.search(lines[3]).group()
-            if available_re.search(lines[3])
-            else 0
+            next(
+                (
+                    available_re.search(line).group()
+                    for line in lines 
+                    if available_re.search(line)
+                ), 0
+            )
         )
 
         waiting_re = re.compile(r'(?<=Slot available after: )[\d\-TZ:]{20}')

--- a/tests/overpass_status/no_slots_waiting_six_lines.txt
+++ b/tests/overpass_status/no_slots_waiting_six_lines.txt
@@ -1,0 +1,6 @@
+Connected as: 0123456789
+Current time: 2022-06-15T22:13:27Z
+Announced endpoint: lz4.overpass-api.de/api/
+Rate limit: 2
+2 slots available now.
+Currently running queries (pid, space limit, time limit, start time):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,6 +90,12 @@ def test_geojson_live():
     "response,slots_available,slots_running,slots_waiting",
     [
         (
+            "tests/overpass_status/no_slots_waiting_extra_lines.txt",
+            2,
+            (),
+            ()
+        ),
+        (
             "tests/overpass_status/no_slots_waiting.txt",
             2,
             (),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -90,7 +90,7 @@ def test_geojson_live():
     "response,slots_available,slots_running,slots_waiting",
     [
         (
-            "tests/overpass_status/no_slots_waiting_extra_lines.txt",
+            "tests/overpass_status/no_slots_waiting_six_lines.txt",
             2,
             (),
             ()


### PR DESCRIPTION
I just discovered the Overpass status page can sometimes have more lines in it than usual, but the code I wrote to check Overpass status assumes there will always be the same number. This PR handles that case and adds a test.