### PR TITLE
Patch critical/high dependency vulnerabilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 ]
 dependencies = [
     "osm2geojson>=0.2.5",
-    "requests>=2.32.3",
+    "requests>=2.32.4",
     "httpx>=0.27.0",
     "pydantic>=2.8.0",
 ]
@@ -32,7 +32,7 @@ dev = [
     "pytest>=7.4.0",
     "geojson>=3.1.0",
     "requests-mock>=1.12.1",
-    "deepdiff>=7.0.1",
+    "deepdiff>=8.6.1",
     "pydantic>=2.8.0",
     "shapely>=2.0.0",
     "pytest-asyncio>=0.23.0",

--- a/uv.lock
+++ b/uv.lock
@@ -284,12 +284,12 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "osm2geojson", specifier = ">=0.2.5" },
     { name = "pydantic", specifier = ">=2.8.0" },
-    { name = "requests", specifier = ">=2.32.3" },
+    { name = "requests", specifier = ">=2.32.4" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "deepdiff", specifier = ">=7.0.1" },
+    { name = "deepdiff", specifier = ">=8.6.1" },
     { name = "geojson", specifier = ">=3.1.0" },
     { name = "pydantic", specifier = ">=2.8.0" },
     { name = "pytest", specifier = ">=7.4.0" },


### PR DESCRIPTION
Bumps requests to >=2.32.4 and deepdiff to >=8.6.1, regenerates uv.lock. This addresses the critical DeepDiff advisory and requests CVE; requests also pulls in patched urllib3.