### PR TITLE
Configure Dependabot for uv

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "maintenance/base-0.8"
+    reviewers:
+      - "mvexel"
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+      python-major:
+        update-types:
+          - "major"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "maintenance/base-0.8"
+    reviewers:
+      - "mvexel"


### PR DESCRIPTION
Adds Dependabot updates for uv and GitHub Actions, scheduled weekly, targeting maintenance/base-0.8, with separate major vs minor/patch groups and mvexel as reviewer.